### PR TITLE
Remove text background panels for conditional formatting

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1458,86 +1458,23 @@ class SeatingChartApp:
                                                  width=max(1, int(1 * self.current_zoom_level)), # Thinner outline for stripes
                                                  tags=rect_tag + (f"stripe_{i}",))
 
-            # --- Text Drawing with Background Panel ---
-            text_panel_fill = "#F0F0F0" # Light gray for text background
-            text_panel_internal_padding = 2 * self.current_zoom_level # Small padding around text within its panel
-
+            # --- Text Drawing (Background Panel Removed) ---
             current_y_text_draw_canvas = canvas_y + canvas_padding
             available_text_width_canvas = canvas_width - 2 * canvas_padding
 
-            # Panel for Name Lines
-            name_lines_content = student_data.get("display_lines", [])
-            if name_lines_content:
-                name_block_height_canvas = 0
-                max_name_width_pixels = 0
-                for name_line_text in name_lines_content:
-                    name_block_height_canvas += name_font_obj.metrics('linespace')
-                    max_name_width_pixels = max(max_name_width_pixels, name_font_obj.measure(name_line_text))
-
-                # Ensure panel width doesn't exceed available text width
-                name_panel_width = min(max_name_width_pixels + 2 * text_panel_internal_padding, available_text_width_canvas - 2 * text_panel_internal_padding)
-                name_panel_height = name_block_height_canvas # Panel is tight to text block height
-
-                name_panel_x0 = canvas_x + (canvas_width - name_panel_width) / 2
-                name_panel_y0 = current_y_text_draw_canvas - text_panel_internal_padding # Start slightly above first text line
-                name_panel_x1 = name_panel_x0 + name_panel_width
-                name_panel_y1 = name_panel_y0 + name_panel_height + 2 * text_panel_internal_padding
-
-                if name_panel_y1 < (canvas_y + canvas_dynamic_height - canvas_padding): # Ensure panel is within box
-                    self.canvas.create_rectangle(name_panel_x0, name_panel_y0, name_panel_x1, name_panel_y1,
-                                                 fill=text_panel_fill, outline="",
-                                                 tags=("student_item", student_id, "text_background_name"))
-
             # Draw Name Lines
+            name_lines_content = student_data.get("display_lines", [])
             for name_line_text in name_lines_content:
                 self.canvas.create_text(canvas_x + canvas_width / 2, current_y_text_draw_canvas, text=name_line_text,
                                         fill=font_color, font=name_font_obj, tags=("student_item", student_id, "text", "student_name"),
                                         anchor=tk.N, width=max(1, available_text_width_canvas), justify=tk.CENTER)
                 current_y_text_draw_canvas += name_font_obj.metrics('linespace')
 
-            # Panel and Drawing for Incident/Score Lines
+            # Draw Incident/Score Lines
             incident_lines_content = student_data.get("incident_display_lines", [])
             if incident_lines_content:
                 current_y_text_draw_canvas += canvas_padding / 2 # Space before incidents
 
-                incident_block_start_y = current_y_text_draw_canvas
-                incident_block_height_canvas = 0
-                max_incident_width_pixels = 0
-
-                for line_info in incident_lines_content:
-                    line_text, line_type = line_info["text"], line_info["type"]
-                    current_font_for_calc = incident_font_obj
-                    if line_type == "quiz_score": current_font_for_calc = quiz_score_font_obj
-                    elif line_type == "homework_score_header": current_font_for_calc = hw_score_font_obj
-                    elif line_type == "homework_score_item": current_font_for_calc = hw_score_item_font_obj
-                    elif line_type == "separator": current_font_for_calc = tkfont.Font(family=font_family, size=max(4, int((font_size_world-2)*self.current_zoom_level)))
-
-                    text_width_pixels_canvas_calc = current_font_for_calc.measure(line_text)
-                    # For incident items, they can be left-aligned, so use almost full available width for calc
-                    available_incident_text_width_calc = available_text_width_canvas - (text_panel_internal_padding if line_type == "homework_score_item" else 0)
-
-                    visual_lines_calc = 1
-                    if available_incident_text_width_calc > 0 and text_width_pixels_canvas_calc > available_incident_text_width_calc:
-                        visual_lines_calc = -(-text_width_pixels_canvas_calc // available_incident_text_width_calc)
-                    incident_block_height_canvas += visual_lines_calc * current_font_for_calc.metrics('linespace')
-                    max_incident_width_pixels = max(max_incident_width_pixels, min(text_width_pixels_canvas_calc, available_incident_text_width_calc))
-
-                incident_panel_width = min(max_incident_width_pixels + 2 * text_panel_internal_padding, available_text_width_canvas - 2 * text_panel_internal_padding)
-                incident_panel_height = incident_block_height_canvas # Tight to text
-
-                inc_panel_x0 = canvas_x + (canvas_width - incident_panel_width) / 2 # Centered panel for incidents block
-                # For homework_score_item which is left aligned, we might want the panel to also be left aligned.
-                # However, for simplicity, let's keep the panel centered for now, text inside will align.
-                inc_panel_y0 = incident_block_start_y - text_panel_internal_padding
-                inc_panel_x1 = inc_panel_x0 + incident_panel_width
-                inc_panel_y1 = inc_panel_y0 + incident_panel_height + 2 * text_panel_internal_padding
-
-                if inc_panel_y1 < (canvas_y + canvas_dynamic_height - canvas_padding * 0.5):
-                     self.canvas.create_rectangle(inc_panel_x0, inc_panel_y0, inc_panel_x1, inc_panel_y1,
-                                                 fill=text_panel_fill, outline="",
-                                                 tags=("student_item", student_id, "text_background_incidents"))
-
-                # Draw Incident/Score Lines
                 for line_info in incident_lines_content:
                     line_text, line_type = line_info["text"], line_info["type"]
                     current_font_canvas_draw, current_color_canvas_draw = incident_font_obj, font_color


### PR DESCRIPTION
Per user request, removed the light gray background panels previously drawn behind student names and incident/score lines.

Text will now be rendered directly on the conditional formatting stripes or the base box color. Legibility will depend on the contrast between the font color and the underlying background color(s).